### PR TITLE
Release 1.5.0

### DIFF
--- a/includes/razorpay-webhook.php
+++ b/includes/razorpay-webhook.php
@@ -51,7 +51,13 @@ class RZP_Webhook
                 }
                 catch (Errors\SignatureVerificationError $e)
                 {
-                    write_log(['message' => $e->getMessage()]);
+                    $log = array(
+                        'message'   => $e->getMessage(),
+                        'data'      => $data,
+                        'event'     => 'razorpay.wc.signature..verify_failed'
+                    );
+
+                    write_log($log);
                     return;
                 }
             }

--- a/razorpay-payments.php
+++ b/razorpay-payments.php
@@ -703,11 +703,15 @@ EOT;
             {
                 $error = $_POST['error'];
 
-                $message = 'An error occured. Description : ' . $error['description'] . '. Code : ' . $error['code'];
+                $description = htmlentities($error['description']);
+                $code = htmlentities($error['code']);
+
+                $message = 'An error occured. Description : ' . $description . '. Code : ' . $code;
 
                 if (isset($error['field']) === true)
                 {
-                    $message .= 'Field : ' . $error['field'];
+                    $fieldError = htmlentities($error['field']);
+                    $message .= 'Field : ' . $fieldError;
                 }
             }
             else

--- a/readme.txt
+++ b/readme.txt
@@ -36,11 +36,12 @@ This is compatible with WooCommerce>=2.4, including the new 3.0 release.
 
 == Changelog ==
 
-= UNRELEASED = 
-* Javascript fixes for additional compatibility
+= 1.5.0 = 
+* Javascript fixes for additional compatibility with other plugins ([#47](https://github.com/razorpay/razorpay-woocommerce/pull/47))
+* Adds multi-currency support using [WooCommerce Currency Switcher](https://wordpress.org/plugins/woocommerce-currency-switcher/) plugin. ([#46](https://github.com/razorpay/razorpay-woocommerce/pull/46))
 
 = 1.4.6 =
-* Webhooks signature verification fix ([#47](https://github.com/razorpay/razorpay-woocommerce/pull/47))
+* Webhooks signature verification fix
 
 = 1.4.4 =
 * Added webhooks to the plugin (includes/razorpay-webhook.php) ([#18](https://github.com/razorpay/razorpay-woocommerce/pull/18))


### PR DESCRIPTION
@albingeorge: Made changes regarding order caching. We were creating double orders for every refresh on non-INR orders. There were also rounding errors that I was getting, so fixed those as well.

@mayankamencherla: There was a security issue with how we were display error messages without sanitization.