### PR TITLE
Update - WC tested up to: 3.6.0

### DIFF
--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -6,7 +6,7 @@
  * Version: 1.6.3
  * Stable tag: 1.6.3
  * Author: Team Razorpay
- * WC tested up to: 3.2.1
+ * WC tested up to: 3.6.0
  * Author URI: https://razorpay.com
 */
 


### PR DESCRIPTION
To prevent the error display in Woocommerce Status as Not tested with the active version of WooCommerce

![image](https://user-images.githubusercontent.com/454883/56346687-56e61a80-61e0-11e9-9af2-7f7390be15f2.png)
