### PR TITLE
Order Number != Order ID

### DIFF
--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -409,9 +409,10 @@ function woocommerce_razorpay_init()
         {
             $callbackUrl = $this->getRedirectUrl();
 
-            $orderId = $order->get_order_number();
+            $orderId = $order->get_id();
+            $orderNum = $order->get_order_number();
 
-            $productinfo = "Order $orderId";
+            $productinfo = "Order $orderNum";
             $mod_version = get_plugin_data(plugin_dir_path(__FILE__) . 'woo-razorpay.php')['Version'];
 
             return array(


### PR DESCRIPTION
Order Number is equal to Order ID by default but that might not always be the case.

Following code expects an Order ID and not an Order Number.
https://github.com/KDSPL/razorpay-woocommerce/blob/master/includes/razorpay-webhook.php#L158

Ref: https://docs.woocommerce.com/document/managing-orders/
> Order IDs are non-sequential as they use the default WordPress ID approach. For sequential order numbers, you can use Sequential Order Numbers Pro.