### PR TITLE
Store Razorpay order_id in WooCommerce order meta

### DIFF
--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -390,6 +390,8 @@ function woocommerce_razorpay_init()
             {
                 return $e->getMessage();
             }
+            
+            $order->update_meta_data('rzp_order_id', $params['order_id']);
 
             $checkoutArgs = $this->getCheckoutArguments($order, $params);
 

--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -409,9 +409,10 @@ function woocommerce_razorpay_init()
         {
             $callbackUrl = $this->getRedirectUrl();
 
-            $orderId = $order->get_order_number();
+            $orderId = $order->get_id();
+            $orderNum = $order->get_order_number();
 
-            $productinfo = "Order $orderId";
+            $productinfo = "Order $orderNum";
             $mod_version = get_plugin_data(plugin_dir_path(__FILE__) . 'woo-razorpay.php')['Version'];
 
             return array(


### PR DESCRIPTION
Since the Razor pay API only allows users to reference orders using the Razor pay order_id it would be useful to retain the Razorpay order_id in WooCommerce for future reference. For example, in an order related automation / order sync process.

#176 