### PR TITLE
Store Razorpay order_id in WooCommerce order meta

### DIFF
--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -391,6 +391,8 @@ function woocommerce_razorpay_init()
                 return $e->getMessage();
             }
 
+            $order->update_meta_data('rzp_order_id', $params['order_id']);
+
             $checkoutArgs = $this->getCheckoutArguments($order, $params);
 
             $html = '<p>'.__('Thank you for your order, please click the button below to pay with Razorpay.', $this->id).'</p>';


### PR DESCRIPTION
Since the Razor pay API only allows users to reference orders using the Razor pay order_id it would be useful to retain the Razorpay order_id in WooCommerce for future reference. For example, in an order related automation / order sync process.