### PR TITLE
Sending order number in notes instead of order id.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: razorpay
 Tags: razorpay, payments, india, woocommerce, ecommerce
 Requires at least: 3.9.2
 Tested up to: 5.7.2
-Stable tag: 2.7.0
+Stable tag: 2.7.1
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -40,6 +40,9 @@ This is compatible with WooCommerce>=2.4, including the new 3.0 release. It has 
 * Switches from WooCommerce side currency conversion to Razorpay's native multi currency support.
 
 == Changelog ==
+
+= 2.7.1 =
+* Update the Razorpay Order notes key.
 
 = 2.7.0 =
 * Added auto-webhook setup feature.

--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -3,8 +3,8 @@
  * Plugin Name: Razorpay for WooCommerce
  * Plugin URI: https://razorpay.com
  * Description: Razorpay Payment Gateway Integration for WooCommerce
- * Version: 2.7.0
- * Stable tag: 2.7.0
+ * Version: 2.7.1
+ * Stable tag: 2.7.1
  * Author: Team Razorpay
  * WC tested up to: 5.3.0
  * Author URI: https://razorpay.com
@@ -45,6 +45,7 @@ function woocommerce_razorpay_init()
         const CAPTURE                        = 'capture';
         const AUTHORIZE                      = 'authorize';
         const WC_ORDER_ID                    = 'woocommerce_order_id';
+        const WC_ORDER_NUMBER                = 'woocommerce_order_number';
 
         const DEFAULT_LABEL                  = 'Credit Card/Debit Card/NetBanking';
         const DEFAULT_DESCRIPTION            = 'Pay securely by Credit or Debit card or Internet Banking through Razorpay.';
@@ -549,7 +550,7 @@ function woocommerce_razorpay_init()
                 'currency'     => self::INR,
                 'description'  => $productinfo,
                 'notes'        => array(
-                    'woocommerce_order_id' => $orderId
+                     self::WC_ORDER_ID => $orderId
                 ),
                 'order_id'     => $razorpayOrderId,
                 'callback_url' => $callbackUrl,
@@ -693,7 +694,7 @@ function woocommerce_razorpay_init()
                 'payment_capture' => ($this->getSetting('payment_action') === self::AUTHORIZE) ? 0 : 1,
                 'app_offer'       => ($order->get_discount_total() > 0) ? 1 : 0,
                 'notes'           => array(
-                    self::WC_ORDER_ID  => (string) $order->get_order_number(),
+                    self::WC_ORDER_NUMBER  => (string) $orderId,
                 ),
             );
 

--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -693,7 +693,7 @@ function woocommerce_razorpay_init()
                 'payment_capture' => ($this->getSetting('payment_action') === self::AUTHORIZE) ? 0 : 1,
                 'app_offer'       => ($order->get_discount_total() > 0) ? 1 : 0,
                 'notes'           => array(
-                    self::WC_ORDER_ID  => (string) $orderId,
+                    self::WC_ORDER_ID  => (string) $order->get_order_number(),
                 ),
             );
 


### PR DESCRIPTION
This will help to map the woocommerce order number with the razorpay dashboard even if the custom order number is used. 