### PR TITLE
Add onboarding setup helper methods

### DIFF
--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -264,6 +264,40 @@ function woocommerce_razorpay_init()
             }
         }
 
+        /**
+         * The required settings for onboarding setup.
+         *
+         * @return array
+         */
+        public function get_required_settings_keys()
+        {
+            return [ 'key_id', 'key_secret' ];
+        }
+
+        /**
+         * Text provided to users during onboarding setup.
+         *
+         * @return string
+         */
+        public function get_setup_help_text()
+        {
+            return sprintf(
+                __('Your key details can be obtained from your <a href="%s" target="_blank">Razorpay account</a>.', $this->id),
+                'https://dashboard.razorpay.com/#/access/signin'
+            );
+        }
+
+        /**
+         * Determine if the gateway still requires setup.
+         *
+         * @return bool
+         */
+        public function needs_setup()
+        {
+            return ! $this->get_option('key_id') || ! $this->get_option('key_secret');
+        }
+
+
         public function autoEnableWebhook()
         {
             $webhookExist = false;


### PR DESCRIPTION
Adds methods to assist in payment gateway setup during WooCommerce onboarding.

### Screenshots

<img width="689" alt="Screen Shot 2021-06-01 at 4 26 28 PM" src="https://user-images.githubusercontent.com/10561050/120386954-4a0cde00-c2f7-11eb-86e5-4eeb6492b47e.png">


### Testing

Follow testing instructions in this PR - https://github.com/woocommerce/woocommerce-admin/pull/7096