### PR TITLE
[PLG-141] Added line items to 1cc rzp order

### DIFF
--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -861,12 +861,12 @@ function woocommerce_razorpay_init()
                $data['line_items'][$i]['type'] = "e-commerce";
                $data['line_items'][$i]['sku'] = $product->get_sku();
                $data['line_items'][$i]['variant_id'] = $item->get_variation_id();
-               $data['line_items'][$i]['price'] = (empty($productDetails['price'])=== false) ? (int)$productDetails['price']*100 : 0;
+               $data['line_items'][$i]['price'] = (empty($productDetails['price'])=== false) ? round(wc_get_price_excluding_tax($product)*100) + round($item->get_subtotal_tax()*100 / $item->get_quantity()) : 0;
                $data['line_items'][$i]['offer_price'] = (empty($productDetails['sale_price'])=== false) ? (int) $productDetails['sale_price']*100 : $productDetails['price']*100;
                $data['line_items'][$i]['tax_amount'] = $item->get_subtotal_tax()*100;
                $data['line_items'][$i]['quantity'] = $item->get_quantity();
                $data['line_items'][$i]['name'] = $item->get_name();
-               $data['line_items'][$i]['description'] = $productDetails['short_description'];
+               $data['line_items'][$i]['description'] = $item->get_name();
                $data['line_items'][$i]['weight'] = $productDetails['weight'];
                $data['line_items'][$i]['image_url'] = wp_get_attachment_url( $product->get_image_id() );
                $data['line_items'][$i]['product_url'] = $product->get_permalink();

--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -851,6 +851,29 @@ function woocommerce_razorpay_init()
             // TODO: trim to 2 deciamls
             $data['line_items_total'] = $order->get_total()*100;
 
+            $i = 0;
+            // Get and Loop Over Order Items
+            foreach ( $order->get_items() as $item_id => $item )
+            {
+               $product = $item->get_product();
+               $productDetails = $product->get_data();
+
+               $data['line_items'][$i]['type'] = "e-commerce";
+               $data['line_items'][$i]['sku'] = $product->get_sku();
+               $data['line_items'][$i]['variant_id'] = $item->get_variation_id();
+               $data['line_items'][$i]['price'] = (empty($productDetails['price'])=== false) ? (int)$productDetails['price']*100 : 0;
+               $data['line_items'][$i]['offer_price'] = (empty($productDetails['sale_price'])=== false) ? (int) $productDetails['sale_price']*100 : $productDetails['price']*100;
+               $data['line_items'][$i]['tax_amount'] = $item->get_subtotal_tax()*100;
+               $data['line_items'][$i]['quantity'] = $item->get_quantity();
+               $data['line_items'][$i]['name'] = $item->get_name();
+               $data['line_items'][$i]['description'] = $productDetails['short_description'];
+               $data['line_items'][$i]['weight'] = $productDetails['weight'];
+               $data['line_items'][$i]['image_url'] = wp_get_attachment_url( $product->get_image_id() );
+               $data['line_items'][$i]['product_url'] = $product->get_permalink();
+
+               $i++;
+            }
+
             return $data;
         }
 

--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -885,12 +885,13 @@ function woocommerce_razorpay_init()
                $data['line_items'][$i]['variant_id'] = $item->get_variation_id();
                $data['line_items'][$i]['price'] = (empty($productDetails['price'])=== false) ? round(wc_get_price_excluding_tax($product)*100) + round($item->get_subtotal_tax()*100 / $item->get_quantity()) : 0;
                $data['line_items'][$i]['offer_price'] = (empty($productDetails['sale_price'])=== false) ? (int) $productDetails['sale_price']*100 : $productDetails['price']*100;
-               $data['line_items'][$i]['tax_amount'] = $item->get_subtotal_tax()*100;
+               $data['line_items'][$i]['tax_amount'] = (int)$item->get_subtotal_tax()*100;
                $data['line_items'][$i]['quantity'] = $item->get_quantity();
                $data['line_items'][$i]['name'] = $item->get_name();
                $data['line_items'][$i]['description'] = $item->get_name();
                $data['line_items'][$i]['weight'] = $productDetails['weight'];
-               $data['line_items'][$i]['image_url'] = wp_get_attachment_url( $product->get_image_id() );
+               $productImage = $product->get_image_id()?? null;
+               $data['line_items'][$i]['image_url'] = $productImage? wp_get_attachment_url( $productImage ) : null;
                $data['line_items'][$i]['product_url'] = $product->get_permalink();
 
                $i++;


### PR DESCRIPTION
Sample data
`{
    "receipt": 8693,
    "amount": 200800,
    "currency": "INR",
    "payment_capture": 1,
    "app_offer": 0,
    "notes": {
        "woocommerce_order_number": "8693"
    },
    "line_items_total": 200800,
    "line_items": [
        {
            "type": "e-commerce",
            "sku": "",
            "variant_id": 0,
            "price": 19900,
            "offer_price": 19900,
            "tax_amount": 30356,
            "quantity": 10,
            "name": "Augue adipiscing euismod",
            "description": "Scelerisque facilisi rhoncus non faucibus parturient senectus lobortis a ullamcorper vestibulum mi nibh ultricies a parturient gravida a vestibulum leo sem in. Est cum torquent mi in scelerisque leo aptent per at vitae ante eleifend mollis adipiscing.",
            "weight": "",
            "image_url": "http:\/\/localhost\/rzp\/wordpress_v56\/wp-content\/uploads\/2021\/08\/variable-product-example-1.jpg",
            "product_url": "http:\/\/localhost\/rzp\/wordpress_v56\/product\/augue-adipiscing-euismod\/"
        },
        {
            "type": "e-commerce",
            "sku": "woo-beanie",
            "variant_id": 0,
            "price": 1800,
            "offer_price": 1800,
            "tax_amount": 275,
            "quantity": 1,
            "name": "Beanie",
            "description": "This is a simple product.",
            "weight": "",
            "image_url": "http:\/\/localhost\/rzp\/wordpress_v56\/wp-content\/uploads\/2021\/08\/beanie-2.jpg",
            "product_url": "http:\/\/localhost\/rzp\/wordpress_v56\/product\/beanie\/"
        }
    ]
}`