### PR TITLE
Update receipt_page code for divi theme

### DIFF
--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -763,18 +763,13 @@ function woocommerce_razorpay_init()
          **/
         function receipt_page($orderId)
         {
-            $current_theme = strtolower(wp_get_theme());
-            
-			if($current_theme === 'divi')
+            foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as $value)
             {
-                foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as $value)
+                if ($value['function'] === 'output' and
+                    stripos($value['file'], 'themes/divi') !== false and
+                    basename($value['file'], ".php") !== 'CheckoutPaymentInfo')
                 {
-                    if ($value['function'] === 'output' and
-                        stripos($value['file'], 'divi') !== false and
-                        basename($value['file'], ".php") !== 'CheckoutPaymentInfo')
-                    {
-                        return;
-                    }
+                    return;
                 }
             }
 

--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -763,12 +763,18 @@ function woocommerce_razorpay_init()
          **/
         function receipt_page($orderId)
         {
-            foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as $value){
-                if ($value['function'] === 'output' and
-                    stripos($value['file'], 'divi') !== false and
-                    basename($value['file'], ".php") !== 'CheckoutPaymentInfo')
+            $current_theme = strtolower(wp_get_theme());
+            
+			if($current_theme === 'divi')
+            {
+                foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as $value)
                 {
-                    return;
+                    if ($value['function'] === 'output' and
+                        stripos($value['file'], 'divi') !== false and
+                        basename($value['file'], ".php") !== 'CheckoutPaymentInfo')
+                    {
+                        return;
+                    }
                 }
             }
 


### PR DESCRIPTION
Added condition to check active theme is set to 'divi' to fix [checkout not rendering](https://razorpay.atlassian.net/browse/PLUG-1507) issues of merchant not using divi theme.
