### PR TITLE
Removed woocommerce-message class to fix redirect issue in Elessi theme

### DIFF
--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -1315,7 +1315,7 @@ function woocommerce_razorpay_init()
     <!-- This distinguishes all our various wordpress plugins -->
     <input type="hidden" name="razorpay_wc_form_submit" value="1">
 </form>
-<p id="msg-razorpay-success" class="woocommerce-info" style="display:none">
+<p id="msg-razorpay-success" class="woocommerce-info" style="display:none;background-color:rgba(176,176,176,.6);padding:1rem 1.5rem 1rem 3.5rem;border-top-style:solid;border-top-width:2px;">
 Please wait while we are processing your payment.
 </p>
 <p>

--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -1315,7 +1315,7 @@ function woocommerce_razorpay_init()
     <!-- This distinguishes all our various wordpress plugins -->
     <input type="hidden" name="razorpay_wc_form_submit" value="1">
 </form>
-<p id="msg-razorpay-success" class="woocommerce-info woocommerce-message" style="display:none">
+<p id="msg-razorpay-success" class="woocommerce-info" style="display:none">
 Please wait while we are processing your payment.
 </p>
 <p>


### PR DESCRIPTION
## Note :- Please follow the below points while attaching test cases document link below:
   ### - If label `Tested` is added then test cases document URL is mandatory.
   ### - Link added should be a valid URL and accessible throughout the org.
   ### - If the branch name contains hotfix / revert by default the BVT workflow check will pass.

| Test Case Document URL                        |
|-----------------------------------------------|
| Please paste test case document link here.... |


Html content of 'woocommerce-message' class is getting replaced to some other text message in Elessi theme.
https://razorpay.atlassian.net/browse/PLUG-1611
Removing this class to fix the issue.