### PR TITLE
fix: converting weight to grams based on wooc weight metric

### DIFF
--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -1383,7 +1383,7 @@ function woocommerce_razorpay_init()
                    $product_id = $product->get_parent_id();
                }
                $data['line_items'][$i]['product_id'] = (string)$product_id;
-			   $data['line_items'][$i]['weight'] = $product->get_weight()*1000*(int)$item->get_quantity();
+			   $data['line_items'][$i]['weight'] = $this->getWeightBasedOnStoreSettingsAndQuantity($product->get_weight(), $item->get_quantity());
                $data['line_items'][$i]['price'] = (empty($productDetails['price'])=== false) ? round(wc_get_price_excluding_tax($product)*100) + round($item->get_subtotal_tax()*100 / $item->get_quantity()) : 0;
                $data['line_items'][$i]['offer_price'] = (empty($productDetails['sale_price'])=== false) ? (int) $productDetails['sale_price']*100 : $productDetails['price']*100;
                $data['line_items'][$i]['quantity'] = (int)$item->get_quantity();
@@ -1397,6 +1397,25 @@ function woocommerce_razorpay_init()
             }
 
             return $data;
+        }
+
+        private function getWeightBasedOnStoreSettingsAndQuantity($weight, $quantity) {
+            $weightMetric = get_option('woocommerce_weight_unit' );
+            $weightInGrams = $weight;
+            switch ($weightMetric) {
+                case 'kg':
+                    $weightInGrams = $weight * 1000;
+                    break;
+                case 'lbs':
+                    $weightInGrams = $weight * 493.592;
+                    break;
+                case 'oz':
+                    $weightInGrams = $weight * 28.3495;
+                    break;
+                default:
+                    rzpLogError("Weight Metric is not supported : " . $weightMetric);
+            }
+            return round($weightInGrams * $quantity);
         }
 
         public function enqueueCheckoutScripts($data)

--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -1383,7 +1383,6 @@ function woocommerce_razorpay_init()
                    $product_id = $product->get_parent_id();
                }
                $data['line_items'][$i]['product_id'] = (string)$product_id;
-
                // wc_get_weight is a woocommerce function which will help us to get weight in desired metric
                // Magic Order expects weight in weight * quantity of line item hence doing the same
                $data['line_items'][$i]['weight'] = round(wc_get_weight($product->get_weight(), 'g', get_option( 'woocommerce_weight_unit', 'g')) * $item->get_quantity());

--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -1383,7 +1383,9 @@ function woocommerce_razorpay_init()
                    $product_id = $product->get_parent_id();
                }
                $data['line_items'][$i]['product_id'] = (string)$product_id;
-			   $data['line_items'][$i]['weight'] = $this->getWeightBasedOnStoreSettingsAndQuantity($product->get_weight(), $item->get_quantity());
+               // wc_get_weight is a woocommerce function which will help us to get weight in desired metric
+               // Magic Order expects weight in weight * quantity of line item hence doing the same
+               $data['line_items'][$i]['weight'] = round(wc_get_weight($product->get_weight(), 'g', get_option( 'woocommerce_weight_unit', 'g')) * $item->get_quantity());
                $data['line_items'][$i]['price'] = (empty($productDetails['price'])=== false) ? round(wc_get_price_excluding_tax($product)*100) + round($item->get_subtotal_tax()*100 / $item->get_quantity()) : 0;
                $data['line_items'][$i]['offer_price'] = (empty($productDetails['sale_price'])=== false) ? (int) $productDetails['sale_price']*100 : $productDetails['price']*100;
                $data['line_items'][$i]['quantity'] = (int)$item->get_quantity();
@@ -1397,25 +1399,6 @@ function woocommerce_razorpay_init()
             }
 
             return $data;
-        }
-
-        private function getWeightBasedOnStoreSettingsAndQuantity($weight, $quantity) {
-            $weightMetric = get_option('woocommerce_weight_unit' );
-            $weightInGrams = $weight;
-            switch ($weightMetric) {
-                case 'kg':
-                    $weightInGrams = $weight * 1000;
-                    break;
-                case 'lbs':
-                    $weightInGrams = $weight * 493.592;
-                    break;
-                case 'oz':
-                    $weightInGrams = $weight * 28.3495;
-                    break;
-                default:
-                    rzpLogError("Weight Metric is not supported : " . $weightMetric);
-            }
-            return round($weightInGrams * $quantity);
         }
 
         public function enqueueCheckoutScripts($data)

--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -1383,6 +1383,7 @@ function woocommerce_razorpay_init()
                    $product_id = $product->get_parent_id();
                }
                $data['line_items'][$i]['product_id'] = (string)$product_id;
+
                // wc_get_weight is a woocommerce function which will help us to get weight in desired metric
                // Magic Order expects weight in weight * quantity of line item hence doing the same
                $data['line_items'][$i]['weight'] = round(wc_get_weight($product->get_weight(), 'g', get_option( 'woocommerce_weight_unit', 'g')) * $item->get_quantity());


### PR DESCRIPTION
## PR Description

### Issue
COD & Shipping fee evaluation are done in a wrong way for woocommerce Merchant who are all having their weight metrics other than kg

### Root Cause
Weight is directly converted to grams with the assumption that it is always in KG.

### Fix
Fetched the store's weight metric configuration and converting the weight to grams based on the metric.