### PR TITLE
Fix: Show checkout button only once on single product page

### DIFF
--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -3520,6 +3520,11 @@ function addRzpSpinner()
 
 function addPdpCheckoutButton()
 {
+    // Runs only on the main single product page (not loops, quick view, or upsells)
+    if ( ! is_product() || ! did_action( 'woocommerce_before_single_product' ) ) {
+        return;
+    }
+
     if (isTestModeEnabled()) {
       $current_user = wp_get_current_user();
       if ($current_user->has_cap( 'administrator' ) || preg_match( '/@razorpay.com$/i', $current_user->user_email )) {


### PR DESCRIPTION
This PR makes sure the checkout button appears only on the main single product page (PDP).  

Some themes reuse the product template inside the PDP (e.g., upsells/related/quick view model), which caused multiple buttons with the same ID (btn-1cc-pdp).  
That broke the modal trigger since duplicate IDs are invalid.  

With this fix:
- Button shows only once on the main PDP
- No duplicate IDs
- Works correctly with modal trigger
