### PR TITLE
[Security] Fix prepayCODOrder - correct meta key lookup and signature verification

### DIFF
--- a/includes/api/api.php
+++ b/includes/api/api.php
@@ -135,7 +135,7 @@ function rzp1ccInitRestApi()
         array(
             'methods'             => 'POST',
             'callback'            => 'prepayCODOrder',
-            'permission_callback' => 'checkAuthCredentials',
+            'permission_callback' => 'checkHmacSignature',
         )
     );
 }

--- a/includes/api/prepay-cod.php
+++ b/includes/api/prepay-cod.php
@@ -12,13 +12,57 @@ function prepayCODOrder(WP_REST_Request $request): WP_REST_Response {
         $payload = $request->get_params();
         $wcRazorpay = new WC_Razorpay(false);
 
-        $orderId = $payload[WC_ORDER_ID];
+        $orderId          = $payload[WC_ORDER_ID];
         $razorpayPaymentId = $payload[RAZORPAY_PAYMENT_ID];
-        $razorpayOrderId = $payload[RAZORPAY_ORDER_ID];
-        $signature = $payload[RAZORPAY_SIGNATURE];
-        $razorpayOffer = $payload[RAZORPAY_OFFER];
+        $razorpayOrderId  = $payload[RAZORPAY_ORDER_ID];
+        $signature        = $payload[RAZORPAY_SIGNATURE];
+        $razorpayOffer    = $payload[RAZORPAY_OFFER];
+
+        // Validate the order exists before any further processing
+        $order = wc_get_order($orderId);
+        if (!$order)
+        {
+            return new WP_REST_Response(['code' => 'invalid_order'], 400);
+        }
+
+        // Prevent double-payment on an already-paid order
+        if ($order->is_paid())
+        {
+            return new WP_REST_Response(['code' => 'order_already_paid'], 400);
+        }
+
+        // Validate that the Razorpay order ID in the request matches what was stored
+        // when the WooCommerce order was created. The stored meta key depends on
+        // whether this is a 1CC (Magic Checkout) order or a standard checkout order:
+        //   1CC orders:  "razorpay_order_id_1cc{orderId}"  (WC_Razorpay::RAZORPAY_ORDER_ID_1CC)
+        //   Standard:    "razorpay_order_id{orderId}"      (WC_Razorpay::RAZORPAY_ORDER_ID)
+        // See WC_Razorpay::getOrderSessionKey() in woo-razorpay.php for the authoritative logic.
+        $is1ccOrder = $order->get_meta('is_magic_checkout_order');
+        if ($is1ccOrder === 'yes')
+        {
+            $sessionKey = 'razorpay_order_id_1cc' . $orderId;
+        }
+        else
+        {
+            $sessionKey = 'razorpay_order_id' . $orderId;
+        }
+
+        $storedRazorpayOrderId = $order->get_meta($sessionKey);
+
+        if (empty($storedRazorpayOrderId))
+        {
+            return new WP_REST_Response(['code' => 'razorpay_order_not_found'], 400);
+        }
+
+        if ($storedRazorpayOrderId !== $razorpayOrderId)
+        {
+            return new WP_REST_Response(['code' => 'razorpay_order_id_mismatch'], 400);
+        }
+
+        // Verify the Razorpay payment signature using the stored order ID (not the
+        // client-supplied one) to close the IDOR window.
         $attributes = array(
-            RAZORPAY_ORDER_ID => $razorpayOrderId,
+            RAZORPAY_ORDER_ID   => $storedRazorpayOrderId,
             RAZORPAY_PAYMENT_ID => $razorpayPaymentId,
             RAZORPAY_SIGNATURE  => $signature,
         );
@@ -31,28 +75,6 @@ function prepayCODOrder(WP_REST_Request $request): WP_REST_Response {
         catch (Exception $e)
         {
             return new WP_REST_Response(["code" => 'woocommerce_order_payment_signature_verfication_failed'], 400);
-        }
-        $order = wc_get_order($orderId);
-
-        if (!$order)
-        {
-            return new WP_REST_Response(['code' => 'invalid_order'], 400);
-        }
-        
-        if ($order->is_paid())
-        {
-            return new WP_REST_Response(['code' => 'order_already_paid'], 400);
-        }
-
-        // Fetch stored Razorpay order ID
-        $storedRazorpayOrderId = $order->get_meta(RAZORPAY_ORDER_ID);
-
-        // Validate binding
-        if ($storedRazorpayOrderId !== $razorpayOrderId)
-        {
-            return new WP_REST_Response([
-                'code' => 'razorpay_order_id_mismatch'
-            ], 400);
         }
 
         if ('on-hold' != $order->get_status())

--- a/includes/api/prepay-cod.php
+++ b/includes/api/prepay-cod.php
@@ -33,6 +33,28 @@ function prepayCODOrder(WP_REST_Request $request): WP_REST_Response {
             return new WP_REST_Response(["code" => 'woocommerce_order_payment_signature_verfication_failed'], 400);
         }
         $order = wc_get_order($orderId);
+
+        if (!$order)
+        {
+            return new WP_REST_Response(['code' => 'invalid_order'], 400);
+        }
+        
+        if ($order->is_paid())
+        {
+            return new WP_REST_Response(['code' => 'order_already_paid'], 400);
+        }
+
+        // Fetch stored Razorpay order ID
+        $storedRazorpayOrderId = $order->get_meta(RAZORPAY_ORDER_ID);
+
+        // Validate binding
+        if ($storedRazorpayOrderId !== $razorpayOrderId)
+        {
+            return new WP_REST_Response([
+                'code' => 'razorpay_order_id_mismatch'
+            ], 400);
+        }
+
         if ('on-hold' != $order->get_status())
         {
             return new WP_REST_Response(['code' => 'woocommerce_order_not_in_on_hold_status'], 400);

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: razorpay
 Tags: razorpay, payments, india, woocommerce, curlec, malaysia, ecommerce, international, cross border
 Requires at least: 3.9.2
 Tested up to: 6.9.4
-Stable tag: 4.8.3
+Stable tag: 4.8.4
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -69,9 +69,11 @@ Razorpay is available for Store Owners and Merchants in
 
 == Changelog ==
 
+= 4.8.4 =
+* Fixed unauthenticated IDOR vulnerability in prepayCODOrder endpoint (CVE-2026-3507).
+
 = 4.8.3 =
 * Added min PHP version to 7.4 .
-* Fixed unauthenticated IDOR vulnerability in prepayCODOrder endpoint (CVE-2026-3507).
 
 = 4.8.2 =
 * Fixed page referer url in case of optional .

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: razorpay
 Tags: razorpay, payments, india, woocommerce, curlec, malaysia, ecommerce, international, cross border
 Requires at least: 3.9.2
 Tested up to: 6.9
-Stable tag: 4.8.2
+Stable tag: 4.8.3
 Requires PHP: 7.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -3,8 +3,8 @@
  * Plugin Name: 1 Razorpay
  * Plugin URI: https://razorpay.com
  * Description: Razorpay Payment Gateway Integration for WooCommerce.Razorpay Welcome Back Offer: New to Razorpay? Sign up to enjoy FREE payments* of INR 2 lakh till March 31st! Transact before January 10th to grab the offer.
- * Version: 4.8.3
- * Stable tag: 4.8.3
+ * Version: 4.8.4
+ * Stable tag: 4.8.4
  * Author: Team Razorpay
  * WC tested up to: 10.6.2
  * Author URI: https://razorpay.com

--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -3,8 +3,8 @@
  * Plugin Name: 1 Razorpay
  * Plugin URI: https://razorpay.com
  * Description: Razorpay Payment Gateway Integration for WooCommerce.Razorpay Welcome Back Offer: New to Razorpay? Sign up to enjoy FREE payments* of INR 2 lakh till March 31st! Transact before January 10th to grab the offer.
- * Version: 4.8.2
- * Stable tag: 4.8.2
+ * Version: 4.8.3
+ * Stable tag: 4.8.3
  * Author: Team Razorpay
  * WC tested up to: 10.3.4
  * Author URI: https://razorpay.com


### PR DESCRIPTION
Validate Razorpay order ID against stored WooCommerce order meta
Add protection against duplicate payment processing
Add HMAC-based authentication using checkHmacSignature

## Note :- Please follow the below points while attaching test cases document link below:
   ### - If label `Tested` is added then test cases document URL is mandatory.
   ### - Link added should be a valid URL and accessible throughout the org.
   ### - If the branch name contains hotfix / revert by default the BVT workflow check will pass.

| Test Case Document URL                        |
|-----------------------------------------------|
| Please paste test case document link here.... |


## Summary                                                                                                                                                                                                
                                                                                                                                                                                                            
  Fixes CVE-2026-3507 — an unauthenticated IDOR vulnerability in the                                                                                                                                        
  `prepayCODOrder` endpoint (`/wp-json/1cc/v1/cod/order/prepay`) that allowed
  attackers to mark any on-hold COD order as paid using a valid Razorpay payment                                                                                                                            
  tuple from their own separate transaction.                                                                                                                                                                
                                                                                                                                                                                                            
  **Current behavior:**                                                                                                                                                                                     
  - Endpoint uses `checkAuthCredentials()` as permission_callback — a no-op                                                                                                                                 
    stub that always returns true. Anyone can call this endpoint without any                                                                                                                                
    authentication.                                                                                                                                                                                         
  - Endpoint accepts whatever `razorpay_order_id` the caller sends without                                                                                                                                  
    verifying it belongs to the specified WooCommerce order. An attacker can                                                                                                                                
    reuse a valid payment tuple from their own ₹1 purchase to mark any victim's                                                                                                                             
    COD order as paid.                                                                                                                                                                                      
                                                                                                                                                                                                            
  **New behavior:**                                                                                                                                                                                         
  - Endpoint requires a valid `X-Razorpay-Signature` HMAC header               
    (`checkHmacSignature`). Only Razorpay's backend (MCS) can call this endpoint.                                                                                                                           
  - The Razorpay order ID is retrieved from WooCommerce order meta (stored at                                                                                                                               
    order creation time) and validated against the client-supplied value before                                                                                                                             
    any processing. Cross-order reuse is rejected.                                                                                                                                                          
  - Signature is verified using the stored order ID, not the client-supplied one.                                                                                                                           
                                                                                                                                                                                                

  Changes

  includes/api/api.php

  Switched permission_callback for the prepay-COD endpoint from
  checkAuthCredentials (no-op) to checkHmacSignature (HMAC-SHA256
  validation using the merchant's stored signing secret).

  includes/api/prepay-cod.php

  Restructured the function with the following fixes:

  1. Moved wc_get_order() before signature verification — order must exist
  and be validated before any crypto operations.
  2. Fixed meta key construction — now correctly builds the session key based
  on whether the order is a Magic Checkout order:
  $is1ccOrder = $order->get_meta('is_magic_checkout_order');
  $sessionKey = ($is1ccOrder === 'yes')
      ? 'razorpay_order_id_1cc' . $orderId
      : 'razorpay_order_id' . $orderId;
  3. Added empty stored order ID check — rejects with razorpay_order_not_found
  if no Razorpay order was ever stored for this WC order.
  4. Signature now uses stored order ID — verifyPaymentSignature() uses
  $storedRazorpayOrderId (fetched from DB) instead of the client-supplied
  $razorpayOrderId, fully closing the IDOR window.

  woo-razorpay.php + readme.txt

  Version bump: 4.8.2 → 4.8.3                                                                                                                                                                               
   