### PR TITLE
fix: handle empty callback POST data with checkout redirect

### DIFF
--- a/context/project-context.json
+++ b/context/project-context.json
@@ -2,7 +2,7 @@
   "project": {
     "name": "razorpay-woocommerce",
     "display_name": "Razorpay Payment Gateway for WooCommerce",
-    "version": "4.8.5",
+    "version": "4.8.6",
     "description": "Official Razorpay payment gateway plugin for WooCommerce. Supports standard checkout, Magic Checkout (1CC), subscriptions, refunds, Route transfers, and webhooks.",
     "language": "PHP",
     "php_version": "7.4+",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: razorpay
 Tags: razorpay, payments, india, woocommerce, curlec, malaysia, ecommerce, international, cross border
 Requires at least: 3.9.2
 Tested up to: 6.9.4
-Stable tag: 4.8.5
+Stable tag: 4.8.6
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -68,6 +68,9 @@ Razorpay is available for Store Owners and Merchants in
 * Switches from WooCommerce side currency conversion to Razorpay's native multi currency support.
 
 == Changelog ==
+
+= 4.8.6 =
+* Fixed empty callback handling to redirect to checkout page.
 
 = 4.8.5 =
 * Version bump to 4.8.5.

--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -3,8 +3,8 @@
  * Plugin Name: 1 Razorpay
  * Plugin URI: https://razorpay.com
  * Description: Razorpay Payment Gateway Integration for WooCommerce.Razorpay Welcome Back Offer: New to Razorpay? Sign up to enjoy FREE payments* of INR 2 lakh till March 31st! Transact before January 10th to grab the offer.
- * Version: 4.8.5
- * Stable tag: 4.8.5
+ * Version: 4.8.6
+ * Stable tag: 4.8.6
  * Author: Team Razorpay
  * WC tested up to: 10.6.2
  * Author URI: https://razorpay.com
@@ -1970,7 +1970,14 @@ EOT;
 
             $post_password = sanitize_text_field($_GET['order_key']);
 
-            rzpLogInfo("Called check_razorpay_response: $post_password");
+            rzpLogInfo("Called check_razorpay_response: $post_password and POST data is " . json_encode($_POST));
+
+            if (empty($_POST))
+            {
+                rzpLogInfo("check_razorpay_response: Empty POST data, redirecting to checkout.");
+                wp_redirect(wc_get_checkout_url());
+                exit;
+            }
 
             $meta_key = '_order_key';
 


### PR DESCRIPTION
## Summary
- Adds early guard in `check_razorpay_response()` to handle empty POST data by redirecting to the checkout URL
- Prevents undefined behavior when the callback endpoint is hit without payment response data
- Bumps plugin version to 4.8.6

## Test plan
- [x] Hit the callback URL (`?wc-api=razorpay`) with no POST data — should redirect to checkout page
- [x] Complete a normal payment flow — should work as before without regression
- [x] Verify redirect works on both HPOS-enabled and legacy stores

🤖 Generated with [Claude Code](https://claude.com/claude-code)