### PR TITLE
chore: bump version to 4.8.7

### DIFF
--- a/.ai/context/CODEBASE_OVERVIEW.md
+++ b/.ai/context/CODEBASE_OVERVIEW.md
@@ -3,7 +3,7 @@
 ## Plugin Identity
 
 - **Name:** 1 Razorpay (prefixed "1" so it appears first in the gateway list)
-- **Version:** 4.8.5
+- **Version:** 4.8.7
 - **Entry Point:** `woo-razorpay.php`
 - **WC Compatibility:** Tested up to WooCommerce 10.6.2
 - **License:** GPL-2.0-or-later

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-This is the **Razorpay WooCommerce Plugin** (v4.8.5), a WordPress payment gateway that integrates Razorpay's payment infrastructure with WooCommerce stores. Written in PHP, it handles payment collection, webhooks, refunds, and an advanced "Magic Checkout" (1CC) one-click checkout experience.
+This is the **Razorpay WooCommerce Plugin** (v4.8.7), a WordPress payment gateway that integrates Razorpay's payment infrastructure with WooCommerce stores. Written in PHP, it handles payment collection, webhooks, refunds, and an advanced "Magic Checkout" (1CC) one-click checkout experience.
 
 ## Technology Stack
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@ This file provides context for GitHub Copilot to give better suggestions for thi
 
 ## Project Context
 
-This is the **Razorpay Payment Gateway plugin for WooCommerce** (WordPress). Version 4.8.5.
+This is the **Razorpay Payment Gateway plugin for WooCommerce** (WordPress). Version 4.8.7.
 
 - **Language:** PHP 7.4+, JavaScript (vanilla)
 - **Framework:** WordPress Plugin API + WooCommerce Payment Gateway

--- a/.kimi/KIMI.md
+++ b/.kimi/KIMI.md
@@ -2,7 +2,7 @@
 
 ## Project Summary
 
-**razorpay-woocommerce** is a PHP WordPress plugin (v4.8.5) that connects WooCommerce e-commerce stores to the Razorpay payment gateway. It supports:
+**razorpay-woocommerce** is a PHP WordPress plugin (v4.8.7) that connects WooCommerce e-commerce stores to the Razorpay payment gateway. It supports:
 - Standard checkout (modal/hosted)
 - Magic Checkout / One Click Checkout (1CC) — streamlined checkout with saved addresses
 - Webhooks for async payment confirmation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 | Attribute | Value |
 |-----------|-------|
 | Plugin Name | Razorpay Payment Gateway for WooCommerce |
-| Version | 4.8.5 |
+| Version | 4.8.7 |
 | Language | PHP 7.4+ |
 | Platform | WordPress + WooCommerce |
 | Entry Point | `woo-razorpay.php` |

--- a/context/project-context.json
+++ b/context/project-context.json
@@ -2,7 +2,7 @@
   "project": {
     "name": "razorpay-woocommerce",
     "display_name": "Razorpay Payment Gateway for WooCommerce",
-    "version": "4.8.6",
+    "version": "4.8.7",
     "description": "Official Razorpay payment gateway plugin for WooCommerce. Supports standard checkout, Magic Checkout (1CC), subscriptions, refunds, Route transfers, and webhooks.",
     "language": "PHP",
     "php_version": "7.4+",

--- a/readme.txt
+++ b/readme.txt
@@ -71,7 +71,7 @@ Razorpay is available for Store Owners and Merchants in
 
 = 4.8.7 =
 * Version bump to 4.8.7.
-* Address sync request cleanup.
+* Added standard checkout address sync support.
 
 = 4.8.6 =
 * Fixed empty callback handling to redirect to checkout page.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: razorpay
 Tags: razorpay, payments, india, woocommerce, curlec, malaysia, ecommerce, international, cross border
 Requires at least: 3.9.2
 Tested up to: 6.9.4
-Stable tag: 4.8.6
+Stable tag: 4.8.7
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -68,6 +68,10 @@ Razorpay is available for Store Owners and Merchants in
 * Switches from WooCommerce side currency conversion to Razorpay's native multi currency support.
 
 == Changelog ==
+
+= 4.8.7 =
+* Version bump to 4.8.7.
+* Address sync request cleanup.
 
 = 4.8.6 =
 * Fixed empty callback handling to redirect to checkout page.

--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -3,8 +3,8 @@
  * Plugin Name: 1 Razorpay
  * Plugin URI: https://razorpay.com
  * Description: Razorpay Payment Gateway Integration for WooCommerce.Razorpay Welcome Back Offer: New to Razorpay? Sign up to enjoy FREE payments* of INR 2 lakh till March 31st! Transact before January 10th to grab the offer.
- * Version: 4.8.6
- * Stable tag: 4.8.6
+ * Version: 4.8.7
+ * Stable tag: 4.8.7
  * Author: Team Razorpay
  * WC tested up to: 10.6.2
  * Author URI: https://razorpay.com


### PR DESCRIPTION
## Summary
- Bumps plugin version to `4.8.7`
- Updates stable tag and changelog

## Test plan
- [x] `php -l woo-razorpay.php`