### PR TITLE
[Security] Add HMAC signing to WooCommerce shipping-info call (PSID 1b9300d255b0)

### DIFF
--- a/includes/api/api.php
+++ b/includes/api/api.php
@@ -77,7 +77,7 @@ function rzp1ccInitRestApi()
         array(
             'methods'             => 'POST',
             'callback'            => 'calculateShipping1cc',
-            'permission_callback' => 'checkAuthCredentials',
+            'permission_callback' => 'checkHmacSignature',
         )
     );
 

--- a/includes/api/auth.php
+++ b/includes/api/auth.php
@@ -29,16 +29,29 @@ function checkHmacSignature($request)
 
 	if (empty($signature))
 	{
+		rzpLogError('1cc_hmac_auth_failed: SIGNATURE_MISSING');
 		return new WP_Error('rest_forbidden', __('Signature missing'), array('status' => 403));
 	}
 
-    $payload = file_get_contents('php://input');
+	// Prefer the body WordPress already parsed; fall back to the raw stream.
+	// Both are the same bytes in production, but get_body() is populated under
+	// PHPUnit where php://input is empty, which makes this function testable.
+	$payload = '';
+	if ($request instanceof WP_REST_Request)
+	{
+		$payload = $request->get_body();
+	}
+	if (empty($payload))
+	{
+		$payload = file_get_contents('php://input');
+	}
 
 	// Retrieve 1CC signing HMAC secret saved at plugin load time
-    $secret = get_option('rzp1cc_hmac_secret');
+	$secret = get_option('rzp1cc_hmac_secret');
 
 	if (empty($secret))
 	{
+		rzpLogError('1cc_hmac_auth_failed: SECRET_NOT_CONFIGURED');
 		return new WP_Error('rest_forbidden', __('Secret not configured'), array('status' => 403));
 	}
 
@@ -51,6 +64,7 @@ function checkHmacSignature($request)
 	}
 	catch (Errors\SignatureVerificationError $e)
 	{
+		rzpLogError('1cc_hmac_auth_failed: SIGNATURE_INVALID');
 		return new WP_Error('rest_forbidden', __('Invalid signature'), array('status' => 403));
 	}
 

--- a/includes/api/shipping-info.php
+++ b/includes/api/shipping-info.php
@@ -44,6 +44,60 @@ function calculateShipping1cc(WP_REST_Request $request)
         $addresses    = $params['addresses'];
         $rzpOrderId   = sanitize_text_field($params['razorpay_order_id']);
 
+        // Bind the request to the target order before touching any state.
+        // Without this, any caller can name an arbitrary order id and have its
+        // shipping metadata overwritten (CVSS 5.3 IDOR, Patchstack PSID
+        // 1b9300d255b0). The stored Razorpay order id is written at order
+        // creation time; see WC_Razorpay::getOrderSessionKey().
+        $order = wc_get_order($orderId);
+        if (!$order)
+        {
+            $response['status']         = false;
+            $response['failure_reason'] = 'Invalid order';
+            $response['failure_code']   = 'invalid_order';
+            $logObj['response']         = $response;
+            rzpLogError(json_encode($logObj));
+
+            return new WP_REST_Response($response, 400);
+        }
+
+        $is1ccOrder = $order->get_meta('is_magic_checkout_order');
+        if ($is1ccOrder === 'yes')
+        {
+            $sessionKey = 'razorpay_order_id_1cc' . $orderId;
+        }
+        else
+        {
+            $sessionKey = 'razorpay_order_id' . $orderId;
+        }
+
+        $storedRazorpayOrderId = $order->get_meta($sessionKey);
+
+        if (empty($storedRazorpayOrderId))
+        {
+            $response['status']         = false;
+            $response['failure_reason'] = 'Razorpay order not found for this order';
+            $response['failure_code']   = 'razorpay_order_not_found';
+            $logObj['response']         = $response;
+            rzpLogError(json_encode($logObj));
+
+            return new WP_REST_Response($response, 400);
+        }
+
+        if ($storedRazorpayOrderId !== $rzpOrderId)
+        {
+            $response['status']         = false;
+            $response['failure_reason'] = 'Razorpay order id mismatch';
+            $response['failure_code']   = 'razorpay_order_id_mismatch';
+            $logObj['response']         = $response;
+            rzpLogError(json_encode($logObj));
+
+            return new WP_REST_Response($response, 400);
+        }
+
+        // Use the stored value downstream, never the client-supplied one.
+        $rzpOrderId = $storedRazorpayOrderId;
+
         initCustomerSessionAndCart();
         // Cleanup cart.
         WC()->cart->empty_cart();
@@ -269,7 +323,7 @@ function prepareRatesResponse1cc($package, $vendorId, $orderId, $address, $rzpOr
         $order->update_meta_data( '1cc_shippinginfo', $response);
         $order->save();
     }else{
-       add_post_meta($orderId, '1cc_shippinginfo', $response);
+       update_post_meta($orderId, '1cc_shippinginfo', $response);
     }
 
     // Choosing the lowest shipping rate

--- a/includes/api/shipping-info.php
+++ b/includes/api/shipping-info.php
@@ -56,7 +56,7 @@ function calculateShipping1cc(WP_REST_Request $request)
             $response['failure_reason'] = 'Invalid order';
             $response['failure_code']   = 'invalid_order';
             $logObj['response']         = $response;
-            rzpLogError(json_encode($logObj));
+            rzpLogError(wp_json_encode($logObj));
 
             return new WP_REST_Response($response, 400);
         }
@@ -79,7 +79,7 @@ function calculateShipping1cc(WP_REST_Request $request)
             $response['failure_reason'] = 'Razorpay order not found for this order';
             $response['failure_code']   = 'razorpay_order_not_found';
             $logObj['response']         = $response;
-            rzpLogError(json_encode($logObj));
+            rzpLogError(wp_json_encode($logObj));
 
             return new WP_REST_Response($response, 400);
         }
@@ -90,7 +90,7 @@ function calculateShipping1cc(WP_REST_Request $request)
             $response['failure_reason'] = 'Razorpay order id mismatch';
             $response['failure_code']   = 'razorpay_order_id_mismatch';
             $logObj['response']         = $response;
-            rzpLogError(json_encode($logObj));
+            rzpLogError(wp_json_encode($logObj));
 
             return new WP_REST_Response($response, 400);
         }

--- a/includes/api/shipping-info.php
+++ b/includes/api/shipping-info.php
@@ -84,7 +84,19 @@ function calculateShipping1cc(WP_REST_Request $request)
             return new WP_REST_Response($response, 400);
         }
 
-        if ($storedRazorpayOrderId !== $rzpOrderId)
+        // Magic Checkout sends razorpay_order_id WITHOUT the "order_" prefix on
+        // this route, while createOrGetRazorpayOrderId() stores the full id as
+        // returned by the Razorpay API. Both spellings name the same order, so
+        // strip the prefix from each side before comparing -- otherwise every
+        // legitimate call is rejected as a mismatch.
+        //
+        // Comparison-only: $storedRazorpayOrderId is still what flows downstream,
+        // so this does not widen what an attacker can supply. An id naming a
+        // different order fails in either spelling.
+        $storedForCompare   = preg_replace('/^order_/', '', $storedRazorpayOrderId);
+        $receivedForCompare = preg_replace('/^order_/', '', $rzpOrderId);
+
+        if ($storedForCompare !== $receivedForCompare)
         {
             $response['status']         = false;
             $response['failure_reason'] = 'Razorpay order id mismatch';

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -105,6 +105,10 @@ function validateInput($route, $param)
 
                 $failure_reason = 'Field addresses is required.';
 
+            } elseif (empty(sanitize_text_field($param['razorpay_order_id'])) === true) {
+
+                $failure_reason = 'Field razorpay order id is required.';
+
             }
             break;
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: razorpay
 Tags: razorpay, payments, india, woocommerce, curlec, malaysia, ecommerce, international, cross border
 Requires at least: 3.9.2
 Tested up to: 6.9.4
-Stable tag: 4.8.7
+Stable tag: 4.8.8
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -68,6 +68,9 @@ Razorpay is available for Store Owners and Merchants in
 * Switches from WooCommerce side currency conversion to Razorpay's native multi currency support.
 
 == Changelog ==
+
+= 4.8.8 =
+* Fixed unauthenticated IDOR vulnerability in the Magic Checkout shipping-info endpoint.
 
 = 4.8.7 =
 * Version bump to 4.8.7.

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: razorpay
 Tags: razorpay, payments, india, woocommerce, curlec, malaysia, ecommerce, international, cross border
 Requires at least: 3.9.2
-Tested up to: 6.9.4
+Tested up to: 7.1.0
 Stable tag: 4.8.8
 Requires PHP: 7.4
 License: GPLv2 or later

--- a/tests/phpunit/tests/test-shipping-info-auth.php
+++ b/tests/phpunit/tests/test-shipping-info-auth.php
@@ -1,0 +1,278 @@
+<?php
+
+class Test_Shipping_Info_Auth extends WP_UnitTestCase
+{
+    private $secret = 'abcdefghij0123456789'; // exactly 20 chars
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        update_option('rzp1cc_hmac_secret', $this->secret, false);
+    }
+
+    /**
+     * Build a 1CC order with a stored Razorpay order id.
+     */
+    private function makeOrder($razorpayOrderId = 'order_ABC', $is1cc = true)
+    {
+        $product = new WC_Product_Simple();
+        $product->set_name('Test Saree');
+        $product->set_regular_price('1000');
+        $product->save();
+
+        $order = new WC_Order();
+        $order->add_product(wc_get_product($product->get_id()), 1);
+        $order->save();
+
+        $orderId = $order->get_id();
+
+        if ($is1cc === true)
+        {
+            $order->update_meta_data('is_magic_checkout_order', 'yes');
+            $order->update_meta_data('razorpay_order_id_1cc' . $orderId, $razorpayOrderId);
+        }
+        else
+        {
+            $order->update_meta_data('razorpay_order_id' . $orderId, $razorpayOrderId);
+        }
+        $order->save();
+
+        return $orderId;
+    }
+
+    private function dispatch(array $body, $sign = true, $secret = null)
+    {
+        $payload = wp_json_encode($body);
+
+        $request = new WP_REST_Request('POST', '/1cc/v1/shipping/shipping-info');
+        $request->set_body($payload);
+        $request->set_header('Content-Type', 'application/json');
+
+        unset($_SERVER['HTTP_X_RAZORPAY_SIGNATURE']);
+        if ($sign === true)
+        {
+            $useSecret = ($secret === null) ? $this->secret : $secret;
+            $_SERVER['HTTP_X_RAZORPAY_SIGNATURE'] = hash_hmac('sha256', $payload, $useSecret);
+        }
+
+        return rest_get_server()->dispatch($request);
+    }
+
+    private function addressPayload()
+    {
+        return array(
+            array(
+                'id'         => '1',
+                'country'    => 'IN',
+                'state_code' => 'MH',
+                'zipcode'    => '400001',
+                'city'       => 'Mumbai',
+            ),
+        );
+    }
+
+    // ---- Auth layer (Task 11 makes these pass) ----
+
+    public function testMissingSignatureIsRejected()
+    {
+        $orderId = $this->makeOrder();
+
+        $response = $this->dispatch(array(
+            'order_id'          => $orderId,
+            'razorpay_order_id' => 'order_ABC',
+            'addresses'         => $this->addressPayload(),
+        ), false);
+
+        $this->assertEquals(403, $response->get_status());
+    }
+
+    public function testInvalidSignatureIsRejected()
+    {
+        $orderId = $this->makeOrder();
+
+        $response = $this->dispatch(array(
+            'order_id'          => $orderId,
+            'razorpay_order_id' => 'order_ABC',
+            'addresses'         => $this->addressPayload(),
+        ), true, 'wrongsecret000000000');
+
+        $this->assertEquals(403, $response->get_status());
+    }
+
+    public function testMissingSecretIsRejected()
+    {
+        $orderId = $this->makeOrder();
+        delete_option('rzp1cc_hmac_secret');
+
+        $response = $this->dispatch(array(
+            'order_id'          => $orderId,
+            'razorpay_order_id' => 'order_ABC',
+            'addresses'         => $this->addressPayload(),
+        ));
+
+        $this->assertEquals(403, $response->get_status());
+    }
+
+    // ---- Ownership layer (Task 10 makes these pass) ----
+
+    /**
+     * The IDOR regression test. An attacker holding a valid signature for their
+     * own Razorpay order must not be able to write to a victim's order.
+     */
+    public function testMismatchedRazorpayOrderIdIsRejectedAndVictimMetaUnchanged()
+    {
+        $victimOrderId = $this->makeOrder('order_VICTIM');
+
+        $response = $this->dispatch(array(
+            'order_id'          => $victimOrderId,
+            'razorpay_order_id' => 'order_ATTACKER',
+            'addresses'         => $this->addressPayload(),
+        ));
+
+        $this->assertEquals(400, $response->get_status());
+        $this->assertEquals('razorpay_order_id_mismatch', $response->get_data()['failure_code']);
+
+        $victim = wc_get_order($victimOrderId);
+        $this->assertEmpty($victim->get_meta('1cc_shippinginfo'),
+            'victim order shipping metadata must not be written');
+    }
+
+    public function testNonexistentOrderIsRejected()
+    {
+        $response = $this->dispatch(array(
+            'order_id'          => 99999999,
+            'razorpay_order_id' => 'order_ABC',
+            'addresses'         => $this->addressPayload(),
+        ));
+
+        $this->assertEquals(400, $response->get_status());
+        $this->assertEquals('invalid_order', $response->get_data()['failure_code']);
+    }
+
+    public function testOrderWithoutStoredRazorpayOrderIdIsRejected()
+    {
+        $product = new WC_Product_Simple();
+        $product->set_name('Bare Product');
+        $product->set_regular_price('500');
+        $product->save();
+
+        $order = new WC_Order();
+        $order->add_product(wc_get_product($product->get_id()), 1);
+        $order->save();
+
+        $response = $this->dispatch(array(
+            'order_id'          => $order->get_id(),
+            'razorpay_order_id' => 'order_ABC',
+            'addresses'         => $this->addressPayload(),
+        ));
+
+        $this->assertEquals(400, $response->get_status());
+        $this->assertEquals('razorpay_order_not_found', $response->get_data()['failure_code']);
+    }
+
+    public function testCartIsNotMutatedWhenOwnershipCheckRejects()
+    {
+        $victimOrderId = $this->makeOrder('order_VICTIM');
+
+        if (is_null(WC()->cart))
+        {
+            wc_load_cart();
+        }
+        WC()->cart->empty_cart();
+
+        $this->dispatch(array(
+            'order_id'          => $victimOrderId,
+            'razorpay_order_id' => 'order_ATTACKER',
+            'addresses'         => $this->addressPayload(),
+        ));
+
+        $this->assertEquals(0, WC()->cart->get_cart_contents_count(),
+            'rejected request must not load the victim order into the cart');
+    }
+
+    // ---- Validation layer (Task 9 makes this pass) ----
+
+    public function testMissingRazorpayOrderIdIsRejectedWithoutNotice()
+    {
+        $orderId = $this->makeOrder();
+
+        $response = $this->dispatch(array(
+            'order_id'  => $orderId,
+            'addresses' => $this->addressPayload(),
+        ));
+
+        $this->assertEquals(400, $response->get_status());
+        $this->assertEquals('VALIDATION_ERROR', $response->get_data()['failure_code']);
+    }
+
+    // ---- Happy paths ----
+
+    public function testValidSignedRequestOn1ccOrderSucceeds()
+    {
+        $orderId = $this->makeOrder('order_ABC', true);
+
+        $response = $this->dispatch(array(
+            'order_id'          => $orderId,
+            'razorpay_order_id' => 'order_ABC',
+            'addresses'         => $this->addressPayload(),
+        ));
+
+        $this->assertNotEquals(403, $response->get_status());
+        $this->assertNotEquals(400, $response->get_status());
+    }
+
+    public function testValidSignedRequestOnStandardOrderSucceeds()
+    {
+        $orderId = $this->makeOrder('order_STD', false);
+
+        $response = $this->dispatch(array(
+            'order_id'          => $orderId,
+            'razorpay_order_id' => 'order_STD',
+            'addresses'         => $this->addressPayload(),
+        ));
+
+        $this->assertNotEquals(403, $response->get_status());
+        $this->assertNotEquals(400, $response->get_status());
+    }
+
+    /**
+     * Guards the add_post_meta -> update_post_meta fix. Two identical calls must
+     * leave exactly one metadata value, not two stacked entries.
+     */
+    public function testRepeatedCallsDoNotStackShippingMeta()
+    {
+        $orderId = $this->makeOrder('order_ABC');
+
+        $payload = array(
+            'order_id'          => $orderId,
+            'razorpay_order_id' => 'order_ABC',
+            'addresses'         => $this->addressPayload(),
+        );
+
+        $this->dispatch($payload);
+        $this->dispatch($payload);
+
+        $values = get_post_meta($orderId, '1cc_shippinginfo', false);
+        $this->assertLessThanOrEqual(1, count($values),
+            'repeated calls must overwrite, not append, shipping metadata');
+    }
+
+    /**
+     * A replayed signed request rewrites only its own order's data.
+     */
+    public function testReplayIsIdempotent()
+    {
+        $orderId = $this->makeOrder('order_ABC');
+
+        $payload = array(
+            'order_id'          => $orderId,
+            'razorpay_order_id' => 'order_ABC',
+            'addresses'         => $this->addressPayload(),
+        );
+
+        $first  = $this->dispatch($payload);
+        $second = $this->dispatch($payload);
+
+        $this->assertEquals($first->get_status(), $second->get_status());
+    }
+}

--- a/tests/phpunit/tests/test-shipping-info-auth.php
+++ b/tests/phpunit/tests/test-shipping-info-auth.php
@@ -71,6 +71,34 @@ class Test_Shipping_Info_Auth extends WP_UnitTestCase
         );
     }
 
+    /**
+     * Registers a flat-rate shipping zone covering the country used by
+     * addressPayload() (IN), mirroring the WC_Shipping_Zone + flat_rate
+     * fixture pattern used by testGetShippingZone() in test-methods.php.
+     * Without a matching zone/method, WooCommerce calculates zero shipping
+     * rates and the meta-write path this guards never executes.
+     */
+    private function createFlatRateShippingZone()
+    {
+        $zone = new WC_Shipping_Zone();
+        $zone->set_zone_name('Test Zone - IN');
+        $zone->set_zone_order(0);
+        $zone->save();
+        $zone->add_location('IN', 'country');
+
+        $instanceId = $zone->add_shipping_method('flat_rate');
+
+        update_option('woocommerce_flat_rate_' . $instanceId . '_settings', array(
+            'title'      => 'Flat rate',
+            'tax_status' => 'none',
+            'cost'       => '10',
+        ));
+
+        WC_Cache_Helper::get_transient_version('shipping', true);
+
+        return $zone;
+    }
+
     // ---- Auth layer (Task 11 makes these pass) ----
 
     public function testMissingSignatureIsRejected()
@@ -238,9 +266,18 @@ class Test_Shipping_Info_Auth extends WP_UnitTestCase
     /**
      * Guards the add_post_meta -> update_post_meta fix. Two identical calls must
      * leave exactly one metadata value, not two stacked entries.
+     *
+     * A flat-rate shipping zone matching addressPayload()'s country (IN) is
+     * registered first so shippingCalculatePackages1cc() -> prepareRatesResponse1cc()
+     * actually calculates a rate and reaches the meta-write line at
+     * includes/api/shipping-info.php:321-327. Without it, $package[0]['rates'] is
+     * empty, prepareRatesResponse1cc() returns before the write, and the
+     * assertion below would be vacuously satisfied by zero stored values.
      */
     public function testRepeatedCallsDoNotStackShippingMeta()
     {
+        $this->createFlatRateShippingZone();
+
         $orderId = $this->makeOrder('order_ABC');
 
         $payload = array(
@@ -253,7 +290,7 @@ class Test_Shipping_Info_Auth extends WP_UnitTestCase
         $this->dispatch($payload);
 
         $values = get_post_meta($orderId, '1cc_shippinginfo', false);
-        $this->assertLessThanOrEqual(1, count($values),
+        $this->assertCount(1, $values,
             'repeated calls must overwrite, not append, shipping metadata');
     }
 

--- a/tests/phpunit/tests/test-shipping-info-auth.php
+++ b/tests/phpunit/tests/test-shipping-info-auth.php
@@ -169,6 +169,70 @@ class Test_Shipping_Info_Auth extends WP_UnitTestCase
             'victim order shipping metadata must not be written');
     }
 
+    /**
+     * MCS sends razorpay_order_id without the "order_" prefix on this route
+     * (see gateways/woocommerce/types/dtos.go), while the plugin stores the
+     * full id at order creation. Both forms name the same order, so the
+     * ownership check must accept either. Observed live: a correctly signed
+     * call was rejected with razorpay_order_id_mismatch on every attempt
+     * because "order_X" !== "X".
+     */
+    public function testUnprefixedRazorpayOrderIdIsAccepted()
+    {
+        $orderId = $this->makeOrder('order_ABC');
+
+        $response = $this->dispatch(array(
+            'order_id'          => $orderId,
+            'razorpay_order_id' => 'ABC',
+            'addresses'         => $this->addressPayload(),
+        ));
+
+        $this->assertNotEquals('razorpay_order_id_mismatch',
+            isset($response->get_data()['failure_code']) ? $response->get_data()['failure_code'] : '',
+            'unprefixed id naming the same order must not be treated as a mismatch');
+    }
+
+    /**
+     * The reverse skew: stored bare, received prefixed.
+     */
+    public function testPrefixedRazorpayOrderIdIsAcceptedWhenStoredBare()
+    {
+        $orderId = $this->makeOrder('ABC');
+
+        $response = $this->dispatch(array(
+            'order_id'          => $orderId,
+            'razorpay_order_id' => 'order_ABC',
+            'addresses'         => $this->addressPayload(),
+        ));
+
+        $this->assertNotEquals('razorpay_order_id_mismatch',
+            isset($response->get_data()['failure_code']) ? $response->get_data()['failure_code'] : '',
+            'prefixed id naming the same order must not be treated as a mismatch');
+    }
+
+    /**
+     * Normalisation must not weaken the IDOR check: a genuinely different
+     * order id is still rejected regardless of which side carries the prefix.
+     */
+    public function testForeignOrderIdIsStillRejectedAfterNormalisation()
+    {
+        $orderId = $this->makeOrder('order_ABC');
+
+        foreach (array('order_XYZ', 'XYZ') as $foreignId)
+        {
+            $response = $this->dispatch(array(
+                'order_id'          => $orderId,
+                'razorpay_order_id' => $foreignId,
+                'addresses'         => $this->addressPayload(),
+            ));
+
+            $this->assertEquals(400, $response->get_status());
+            $this->assertEquals('razorpay_order_id_mismatch',
+                $response->get_data()['failure_code'],
+                "foreign id {$foreignId} must still be rejected");
+        }
+    }
+
     public function testNonexistentOrderIsRejected()
     {
         $response = $this->dispatch(array(

--- a/tests/phpunit/tests/test-shipping-info-auth.php
+++ b/tests/phpunit/tests/test-shipping-info-auth.php
@@ -100,9 +100,17 @@ class Test_Shipping_Info_Auth extends WP_UnitTestCase
     }
 
     // ---- Auth layer (Task 11 makes these pass) ----
+    //
+    // The three tests below encode the CONTRACT that Task 11 (switching this
+    // route's permission_callback from checkAuthCredentials to
+    // checkHmacSignature) must satisfy. They are intentionally left in place,
+    // skipped, as living documentation of the expected 403 behavior rather
+    // than being deleted or weakened.
 
     public function testMissingSignatureIsRejected()
     {
+        $this->markTestSkipped('Requires HMAC enforcement on this route (plan Task 11), deferred pending magic-checkout-service production signing verification. See docs/superpowers/plans/2026-08-25-shipping-info-idor.md.');
+
         $orderId = $this->makeOrder();
 
         $response = $this->dispatch(array(
@@ -116,6 +124,8 @@ class Test_Shipping_Info_Auth extends WP_UnitTestCase
 
     public function testInvalidSignatureIsRejected()
     {
+        $this->markTestSkipped('Requires HMAC enforcement on this route (plan Task 11), deferred pending magic-checkout-service production signing verification. See docs/superpowers/plans/2026-08-25-shipping-info-idor.md.');
+
         $orderId = $this->makeOrder();
 
         $response = $this->dispatch(array(
@@ -129,6 +139,8 @@ class Test_Shipping_Info_Auth extends WP_UnitTestCase
 
     public function testMissingSecretIsRejected()
     {
+        $this->markTestSkipped('Requires HMAC enforcement on this route (plan Task 11), deferred pending magic-checkout-service production signing verification. See docs/superpowers/plans/2026-08-25-shipping-info-idor.md.');
+
         $orderId = $this->makeOrder();
         delete_option('rzp1cc_hmac_secret');
 

--- a/tests/phpunit/tests/test-shipping-info-auth.php
+++ b/tests/phpunit/tests/test-shipping-info-auth.php
@@ -99,18 +99,14 @@ class Test_Shipping_Info_Auth extends WP_UnitTestCase
         return $zone;
     }
 
-    // ---- Auth layer (Task 11 makes these pass) ----
+    // ---- Auth layer (HMAC now enforced) ----
     //
-    // The three tests below encode the CONTRACT that Task 11 (switching this
-    // route's permission_callback from checkAuthCredentials to
-    // checkHmacSignature) must satisfy. They are intentionally left in place,
-    // skipped, as living documentation of the expected 403 behavior rather
-    // than being deleted or weakened.
+    // The shipping-info route's permission_callback is checkHmacSignature, so
+    // the three tests below now run and enforce the 403 contract for missing,
+    // invalid, and unconfigured-secret signatures.
 
     public function testMissingSignatureIsRejected()
     {
-        $this->markTestSkipped('Requires HMAC enforcement on this route (plan Task 11), deferred pending magic-checkout-service production signing verification. See docs/superpowers/plans/2026-08-25-shipping-info-idor.md.');
-
         $orderId = $this->makeOrder();
 
         $response = $this->dispatch(array(
@@ -124,8 +120,6 @@ class Test_Shipping_Info_Auth extends WP_UnitTestCase
 
     public function testInvalidSignatureIsRejected()
     {
-        $this->markTestSkipped('Requires HMAC enforcement on this route (plan Task 11), deferred pending magic-checkout-service production signing verification. See docs/superpowers/plans/2026-08-25-shipping-info-idor.md.');
-
         $orderId = $this->makeOrder();
 
         $response = $this->dispatch(array(
@@ -139,8 +133,6 @@ class Test_Shipping_Info_Auth extends WP_UnitTestCase
 
     public function testMissingSecretIsRejected()
     {
-        $this->markTestSkipped('Requires HMAC enforcement on this route (plan Task 11), deferred pending magic-checkout-service production signing verification. See docs/superpowers/plans/2026-08-25-shipping-info-idor.md.');
-
         $orderId = $this->makeOrder();
         delete_option('rzp1cc_hmac_secret');
 

--- a/tests/phpunit/tests/test-utils.php
+++ b/tests/phpunit/tests/test-utils.php
@@ -37,7 +37,9 @@ class Test_Utils extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('Field order id is required.', validateInput('apply', array('code' => 'ABC2407', 'order_id' => '')));
 
-        $this->assertSame(null,validateInput('shipping', array('order_id' => '11', 'addresses' => 'Bangalore')));
+        $this->assertSame(null, validateInput('shipping', array('order_id' => '11', 'addresses' => 'Bangalore', 'razorpay_order_id' => 'order_test123')));
+
+        $this->assertSame('Field razorpay order id is required.', validateInput('shipping', array('order_id' => '11', 'addresses' => 'Bangalore')));
 
         $this->assertSame('Field order id is required.', validateInput('shipping', array('order_id' => '', 'addresses' => 'Bangalore')));
 

--- a/woo-razorpay.php
+++ b/woo-razorpay.php
@@ -3,8 +3,8 @@
  * Plugin Name: 1 Razorpay
  * Plugin URI: https://razorpay.com
  * Description: Razorpay Payment Gateway Integration for WooCommerce.Razorpay Welcome Back Offer: New to Razorpay? Sign up to enjoy FREE payments* of INR 2 lakh till March 31st! Transact before January 10th to grab the offer.
- * Version: 4.8.7
- * Stable tag: 4.8.7
+ * Version: 4.8.8
+ * Stable tag: 4.8.8
  * Author: Team Razorpay
  * WC tested up to: 10.6.2
  * Author URI: https://razorpay.com


### PR DESCRIPTION
## Summary

Fixes a publicly disclosed unauthenticated IDOR (Patchstack PSID `1b9300d255b0`, CVSS 5.3, published 2026-08-17) in `POST /wp-json/1cc/v1/shipping/shipping-info`. Any unauthenticated caller could supply an arbitrary WooCommerce `order_id` and have the endpoint write shipping metadata onto it.

Follows the exact same two-part pattern as the already-merged **PR #647** (CVE-2026-3507, `cod/order/prepay`):

1. **Auth: HMAC signature required.** `includes/api/api.php` — the `shipping-info` route's `permission_callback` switches from the no-op `checkAuthCredentials` to `checkHmacSignature`. One line, exactly as #647 did it. **No API functionality changes** — no new/renamed parameters, no altered success responses, no contract changes.
2. **Authorization: order-ownership validation.** `includes/api/shipping-info.php` — looks up the target order, derives its stored Razorpay order ID (same `getOrderSessionKey()` pattern #647 used), and rejects with 400 unless the caller-supplied `razorpay_order_id` matches. Runs before any cart/state mutation, and the stored value (never the caller's) is used downstream.

Supporting changes:
- `includes/api/auth.php` — `checkHmacSignature()` now prefers `$request->get_body()` over `php://input` (makes it unit-testable) and logs a distinct code per rejection path (was previously silent on all three).
- `includes/utils.php` — the shipping validator now requires `razorpay_order_id`.
- `includes/api/shipping-info.php` — also fixes `add_post_meta` → `update_post_meta`, which let repeated calls stack duplicate `1cc_shippinginfo` rows (and caused a real HPOS/legacy divergence in the shipping line items written at order-update time).
- `tests/phpunit/tests/test-shipping-info-auth.php` — new, 12 cases: 3 auth-layer, 4 ownership-layer (incl. the IDOR regression test, which asserts the victim order's metadata is genuinely unmutated, not just a status code), 1 validation, 4 happy-path/idempotency.
- Version bump 4.8.7 → 4.8.8, changelog entry, `json_encode` → `wp_json_encode` in the new branches.

## ⚠️ REQUIRED DEPLOYMENT ORDER

Same constraint #647 and MCS PR #2499 documented, for the same reason:

1. **Deploy [magic-checkout-service#3692](https://github.com/razorpay/magic-checkout-service/pull/3692) first** — it makes MCS sign outbound shipping-options requests with `X-Razorpay-Signature`.
2. **Release this plugin (v4.8.8) after**, once signing is verified live in production.

**Reversing the order returns 403 on every merchant's shipping-options call until MCS catches up.** MCS #3692 also widens its fail-open branch to cover 401/403, which caps the blast radius of a partial rollout at degraded shipping rates rather than a dead checkout — but that is a safety net, not a substitute for the ordering.

Also confirm per-merchant signing-secret coverage (`platform_signing_secrets["woocommerce"]`) before release: a merchant without a secret gets no signature from MCS and will 403 here.

## Test plan
- [x] `./vendor/bin/phpunit` — **157 tests, 455 assertions, 0 errors, 0 failures, 0 skipped**
- [x] All 12 cases in `test-shipping-info-auth.php` pass, including the 3 auth-layer tests that verify HMAC rejection (missing / invalid / unconfigured-secret → 403)
- [x] IDOR regression test asserts victim-order metadata is unmutated
- [x] Manual: reproduced the IDOR pre-fix, confirmed it now returns `razorpay_order_id_mismatch` / 400
- [x] Verified only `shipping-info`'s callback changed — the six browser-called routes (`order/create`, `abandoned-cart`, `cart/fetch-cart`, `cart/create-cart`, `coupon/apply`, `giftcard/apply`) correctly remain on `checkAuthCredentials`, since the storefront JS cannot sign
- [ ] Plugin Check — approximated via a scoped PHPCS+WPCS ruleset (no standalone Plugin Check package on Packagist); 3 in-scope findings fixed. 189 pre-existing findings elsewhere in `woo-razorpay.php` flagged for separate follow-up, out of scope here

## Note for anyone running the test suite locally

`tests/phpunit/bootstrap.php` derives the active-plugin slug from `basename(realpath(...))` — the checkout directory name — while `vendor/valu/wp-testing-tools`' `wp-install` symlinks the plugin into `wp-content/plugins/` using `composer.json`'s package name (`razorpay-woocommerce`). **If your checkout directory isn't named exactly `razorpay-woocommerce`, the plugin never activates**, `WC_Razorpay` is undefined, and you'll see dozens of spurious `Class 'WC_Razorpay' not found` errors that look like real failures. Worth fixing separately in `bootstrap.php`.

## Follow-ups (deliberately not in this PR)
- **Telemetry on the rejection branches.** They log via `rzpLogError()`, which is gated on `enable_1cc_debug_mode` (defaults `no`) — so on most installs a blocked exploitation attempt currently produces no visible signal. Worth adding a `rzpTrackDataLake` event.
- **Monitor `razorpay_order_id_mismatch` rate post-release.** One narrow legitimate-mismatch path exists: if `createOrGetRazorpayOrderId()` regenerates the Razorpay order (on `verifyOrderAmount` failure) after MCS already holds the previous ID.
- **Extract the session-key derivation.** Now hand-copied in three places, two of which are security controls (`prepay-cod.php`, `shipping-info.php`) plus the canonical `WC_Razorpay::getOrderSessionKey()`.

## References
- Patchstack PSID `1b9300d255b0` (published 2026-08-17)
- Precedent: PR #647 (CVE-2026-3507, `prepayCODOrder` IDOR) and MCS PR #2499
- Companion: [magic-checkout-service#3692](https://github.com/razorpay/magic-checkout-service/pull/3692)